### PR TITLE
Fix ts error

### DIFF
--- a/lib/sifter.ts
+++ b/lib/sifter.ts
@@ -344,7 +344,7 @@ export default class Sifter{
 				}
 			});
 		} else {
-			iterate(self.items, (item:T.ResultItem, id:string|number) => {
+			iterate(self.items, (_:T.ResultItem, id:string|number) => {
 				search.items.push({'score': 1, 'id': id});
 			});
 		}


### PR DESCRIPTION
`item` isn't used here so TypeScript throws an `unused variable` error.

For some reason, this error bubbles up when using `tsc` in my project, even with `skipLibCheck` enabled and adding `node_modules` to the `exclude` array in my tsconfig.

(loving tom-select btw, great work!)