### PR TITLE
Fix of using implicit type any

### DIFF
--- a/lib/sifter.ts
+++ b/lib/sifter.ts
@@ -23,7 +23,7 @@ import * as T from 'types.ts';
 
 export default class Sifter{
 
-	public items; // []|{};
+	public items: any; // []|{};
 	public settings: T.Settings;
 
 	/**


### PR DESCRIPTION
When using this plugin with strict mode, there is an error using implicit type any:
```
ERROR in [at-loader] ./node_modules/@orchidjs/sifter/lib/sifter.ts:26:9
    TS7008: Member 'items' implicitly has an 'any' type.
```
This commit fixes the problem. Constructor uses type any for items, so this just defines it on property as well.