### PR TITLE
Types imported as type

### DIFF
--- a/lib/sifter.ts
+++ b/lib/sifter.ts
@@ -16,7 +16,7 @@
 
 import { scoreValue, getAttr, getAttrNesting, propToArray, iterate, cmp } from './utils';
 import { getPattern, escape_regex } from '@orchidjs/unicode-variants';
-import * as T from './types';
+import type * as T from './types';
 
 class Sifter{
 


### PR DESCRIPTION
Resolves: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.